### PR TITLE
Remove verbose logging setup

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -60,5 +60,10 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(
+        level=logging.INFO,
+        filename="api_requests_error.log",
+        filemode="w",
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
     main()

--- a/tools/functions.py
+++ b/tools/functions.py
@@ -17,15 +17,6 @@ async def manage_asyncio_wait(pending: List[asyncio.Task]) -> None:
 
     :param pending: Список задач.
     """
-    logging_options = [logging.basicConfig(level=logging.INFO,
-                                           filename="api_requests_error.log",
-                                           filemode="w",
-                                           format="%(asctime)s %(levelname)s %(message)s"),
-                       logging.debug("A DEBUG Message"),
-                       logging.info("An INFO"),
-                       logging.warning("A WARNING"),
-                       logging.error("An ERROR"),
-                       logging.critical("A message of CRITICAL severity")]
     while pending:
         done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
 


### PR DESCRIPTION
## Summary
- clean up verbose logging initialization in `manage_asyncio_wait`
- configure logging once in `bot.py`

## Testing
- `pytest -q`
- `python -m py_compile bot.py tools/functions.py`


------
https://chatgpt.com/codex/tasks/task_e_68759c7901808330a8383710c7b9b61f